### PR TITLE
feat: build page

### DIFF
--- a/src/app.pcss
+++ b/src/app.pcss
@@ -1,81 +1,23 @@
-:root {
-	--colors-top: #191919;
-	--colors-ultra-high: #303030;
-	--colors-high: #555;
-	--colors-low: #e7e7e7;
-	--colors-ultra-low: #f9f9f9;
-	--colors-base: #fefefe;
-
-	--colors-dark-top: #fefefe;
-	--colors-dark-ultra-high: #f9f9f9;
-	--colors-dark-high: #e7e7e7;
-	--colors-dark-low: #555;
-	--colors-dark-ultra-low: #303030;
-	--colors-dark-base: #191919;
-
-	--colors-light-top: #191919;
-	--colors-light-ultra-high: #303030;
-	--colors-light-high: #555;
-	--colors-light-low: #e7e7e7;
-	--colors-light-ultra-low: #f9f9f9;
-	--colors-light-base: #fefefe;
-
-	--colors-dark-overlay: rgba(25, 25, 25, 0.7);
-	--colors-light-overlay: rgba(254, 254, 254, 0.7);
-
-	--font-family-sans-serif: sans-serif;
-	--font-family-serif: serif;
-	--font-family-monospace: monospace;
-
-	--font-size-large: 1.5rem;
-	--font-size: 1rem;
-	--font-size-small: 0.75rem;
-
-	--line-height-large: 2rem;
-	--line-height: 1.5rem;
-	--line-height-small: 1rem;
-
-	--letter-spacing-large: 0.03rem;
-	--letter-spacing: 0.02rem;
-	--letter-spacing-small: 0.0375rem;
-
-	--font-size-h1: 3rem;
-	--font-size-h2: 2.5rem;
-	--font-size-h3: 2rem;
-	--font-size-h4: 1.5rem;
-	--font-size-h5: 1rem;
-	--font-size-h6: 0.75rem;
-
-	--font-weight-h1: 700;
-	--font-weight-h2: 700;
-	--font-weight-h3: 700;
-	--font-weight-h4: 700;
-	--font-weight-h5: 700;
-	--font-weight-h6: 700;
-
-	--line-height-h1: 3.5rem;
-	--line-height-h2: 3rem;
-	--line-height-h3: 2.5rem;
-	--line-height-h4: 2rem;
-	--line-height-h5: 1.5rem;
-	--line-height-h6: 1rem;
-
-	--letter-spacing-h4: 0.03rem;
-	--letter-spacing-h5: 0.02rem;
-	--letter-spacing-h6: 0.0375rem;
-
-	--padding: var(--font-size);
-	--double-padding: calc(2 * var(--padding));
-	--half-padding: calc(var(--padding) / 2);
-	--border-radius: 0.25rem;
-}
-
 body {
 	margin: 0;
 	background-color: var(--colors-base);
 }
 a {
 	color: var(--colors-top);
+}
+ol {
+	list-style: none;
+	counter-reset: li;
+	margin-left: 0;
+	padding-left: 0;
+}
+ol li:before {
+	content: counter(li) ". ";
+	color: var(--colors-top);
+	font-family: var(--font-family-sans-serif);
+}
+ol li {
+	counter-increment: li;
 }
 * {
 	&:focus-visible:not(:disabled) {

--- a/src/app.pcss
+++ b/src/app.pcss
@@ -6,13 +6,13 @@ a {
 	color: var(--colors-top);
 }
 ol {
-	list-style: none;
 	counter-reset: li;
 	margin-left: 0;
 	padding-left: 0;
+	list-style: none;
 }
 ol li:before {
-	content: counter(li) ". ";
+	content: counter(li) '. ';
 	color: var(--colors-top);
 	font-family: var(--font-family-sans-serif);
 }

--- a/src/app.pcss
+++ b/src/app.pcss
@@ -5,20 +5,6 @@ body {
 a {
 	color: var(--colors-top);
 }
-ol {
-	counter-reset: li;
-	margin-left: 0;
-	padding-left: 0;
-	list-style: none;
-}
-ol li:before {
-	content: counter(li) '. ';
-	color: var(--colors-top);
-	font-family: var(--font-family-sans-serif);
-}
-ol li {
-	counter-increment: li;
-}
 * {
 	&:focus-visible:not(:disabled) {
 		outline: 4px solid var(--colors-top);

--- a/src/diete.css
+++ b/src/diete.css
@@ -1,0 +1,71 @@
+:root {
+	--colors-top: #191919;
+	--colors-ultra-high: #303030;
+	--colors-high: #555;
+	--colors-low: #e7e7e7;
+	--colors-ultra-low: #f9f9f9;
+	--colors-base: #fefefe;
+
+	--colors-dark-top: #fefefe;
+	--colors-dark-ultra-high: #f9f9f9;
+	--colors-dark-high: #e7e7e7;
+	--colors-dark-low: #555;
+	--colors-dark-ultra-low: #303030;
+	--colors-dark-base: #191919;
+
+	--colors-light-top: #191919;
+	--colors-light-ultra-high: #303030;
+	--colors-light-high: #555;
+	--colors-light-low: #e7e7e7;
+	--colors-light-ultra-low: #f9f9f9;
+	--colors-light-base: #fefefe;
+
+	--colors-dark-overlay: rgba(25, 25, 25, 0.7);
+	--colors-light-overlay: rgba(254, 254, 254, 0.7);
+
+	--font-family-sans-serif: sans-serif;
+	--font-family-serif: serif;
+	--font-family-monospace: monospace;
+
+	--font-size-large: 1.5rem;
+	--font-size: 1rem;
+	--font-size-small: 0.75rem;
+
+	--line-height-large: 2rem;
+	--line-height: 1.5rem;
+	--line-height-small: 1rem;
+
+	--letter-spacing-large: 0.03rem;
+	--letter-spacing: 0.02rem;
+	--letter-spacing-small: 0.0375rem;
+
+	--font-size-h1: 3rem;
+	--font-size-h2: 2.5rem;
+	--font-size-h3: 2rem;
+	--font-size-h4: 1.5rem;
+	--font-size-h5: 1rem;
+	--font-size-h6: 0.75rem;
+
+	--font-weight-h1: 700;
+	--font-weight-h2: 700;
+	--font-weight-h3: 700;
+	--font-weight-h4: 700;
+	--font-weight-h5: 700;
+	--font-weight-h6: 700;
+
+	--line-height-h1: 3.5rem;
+	--line-height-h2: 3rem;
+	--line-height-h3: 2.5rem;
+	--line-height-h4: 2rem;
+	--line-height-h5: 1.5rem;
+	--line-height-h6: 1rem;
+
+	--letter-spacing-h4: 0.03rem;
+	--letter-spacing-h5: 0.02rem;
+	--letter-spacing-h6: 0.0375rem;
+
+	--padding: var(--font-size);
+	--double-padding: calc(2 * var(--padding));
+	--half-padding: calc(var(--padding) / 2);
+	--border-radius: 0.25rem;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -16,6 +16,7 @@
 	let innerWidth: number | undefined = $state()
 
 	const mobileWidth = 700
+	const menuAlwaysOpen = true
 
 	const menu: { [title: string]: { [path: string]: string } } = {
 		Diète: {
@@ -73,7 +74,9 @@
 	function makeMenuItemOpenMapping() {
 		const menuOpen: { [title: string]: boolean } = {}
 
-		Object.keys(menu).forEach((menu) => (menuOpen[menu] = true || isActivePageInMenu(menu)))
+		Object.keys(menu).forEach(
+			(menu) => (menuOpen[menu] = menuAlwaysOpen || isActivePageInMenu(menu)),
+		)
 
 		return menuOpen
 	}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -21,6 +21,7 @@
 		Diète: {
 			'/': 'Intro',
 			'/build': 'Build with Diète',
+			'/colors': 'CSS colors',
 			'https://github.com/diete-design/diete.design': 'Github',
 		},
 		'Basic components': {
@@ -72,7 +73,7 @@
 	function makeMenuItemOpenMapping() {
 		const menuOpen: { [title: string]: boolean } = {}
 
-		Object.keys(menu).forEach((menu) => (menuOpen[menu] = isActivePageInMenu(menu)))
+		Object.keys(menu).forEach((menu) => (menuOpen[menu] = true || isActivePageInMenu(menu)))
 
 		return menuOpen
 	}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -124,7 +124,7 @@
 						{#each Object.entries(pages) as [path, title]}
 							<MenuItem active={isActivePage(path)} href={path} onclick={menuOnClick}
 								>{#if isExternalLink(path)}
-									<Launch size={24}/>
+									<Launch size={24} />
 								{/if}{title}</MenuItem
 							>
 						{/each}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,8 +3,9 @@
 	import MenuTitle from '$lib/components/ui/menu/menu-title.svelte'
 	import Typography from '$lib/components/ui/typography.svelte'
 	import Button from '$lib/components/ui/button.svelte'
-	import { Light, SidePanelCloseFilled, SidePanelOpenFilled } from 'carbon-icons-svelte'
+	import { Light, SidePanelCloseFilled, SidePanelOpenFilled, Launch } from 'carbon-icons-svelte'
 	import '../app.pcss'
+	import '../diete.css'
 	import Dropdown from '$lib/components/custom/dropdown.svelte'
 	import ThemeSelector from '$lib/components/custom/theme-selector.svelte'
 	import { page } from '$app/stores'
@@ -19,6 +20,8 @@
 	const menu: { [title: string]: { [path: string]: string } } = {
 		Diète: {
 			'/': 'Intro',
+			'/build': 'Build with Diète',
+			'https://github.com/diete-design/diete.design': 'Github',
 		},
 		'Basic components': {
 			'/components/badge': 'Badge',
@@ -74,6 +77,10 @@
 		return menuOpen
 	}
 
+	function isExternalLink(link: string) {
+		return link.startsWith('https://')
+	}
+
 	function menuOnClick() {
 		// close the menu after a click on mobile
 		if (innerWidth && innerWidth < mobileWidth) {
@@ -89,7 +96,7 @@
 <svelte:window bind:innerWidth />
 
 <div class="menu-button-container">
-	<Button variant={isMenuOpen ? 'ghost' : 'solid'} onclick={() => (isMenuOpen = !isMenuOpen)}>
+	<Button variant="solid" onclick={() => (isMenuOpen = !isMenuOpen)}>
 		{#if isMenuOpen}
 			<SidePanelCloseFilled size={24} />
 		{:else}
@@ -116,7 +123,9 @@
 					<MenuTitle content={title} bold bind:open={menuTitleIsOpen[title]}>
 						{#each Object.entries(pages) as [path, title]}
 							<MenuItem active={isActivePage(path)} href={path} onclick={menuOnClick}
-								>{title}</MenuItem
+								>{#if isExternalLink(path)}
+									<Launch size={24}/>
+								{/if}{title}</MenuItem
 							>
 						{/each}
 					</MenuTitle>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -122,7 +122,11 @@
 				{#each Object.entries(menu) as [title, pages]}
 					<MenuTitle content={title} bold bind:open={menuTitleIsOpen[title]}>
 						{#each Object.entries(pages) as [path, title]}
-							<MenuItem active={isActivePage(path)} href={path} onclick={menuOnClick}
+							<MenuItem
+								active={isActivePage(path)}
+								href={path}
+								onclick={menuOnClick}
+								target={isExternalLink(path) ? '_blank' : undefined}
 								>{#if isExternalLink(path)}
 									<Launch size={24} />
 								{/if}{title}</MenuItem

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -42,7 +42,7 @@
 
 <section id="call-to-action">
 	<Button variant="strong" dimension="large" href="/components/button">Explore components</Button>
-	<Button variant="secondary" dimension="large" href="/components/button">Learn more</Button>
+	<Button variant="secondary" dimension="large" href="/build">Learn more</Button>
 </section>
 
 <hr />

--- a/src/routes/build/+page.svelte
+++ b/src/routes/build/+page.svelte
@@ -6,7 +6,7 @@
 <Typography variant="h3">Build with Diète</Typography>
 
 <section id="introduction">
-	<Typography>
+	<Typography variant="large">
 		Diète is an open-source design system. Guided by an essential design approach, built with the
 		highest usability standards, it lays great emphasis on accessibility and flexibility. UI
 		components can be copy-pasted directly into your own code, easily customised and assembled
@@ -56,48 +56,28 @@
 	<section id="essential-design">
 		<Typography variant="h5" class="box-title">Essential design</Typography>
 		<Typography>
-			Diète aims for simplicity and timeless design by avoiding superfluous effects or trendy
-			styles. Not merely the superficial simplicity that comes from a minimalist appearance, but the
-			simplicity that stems from deeply understanding the underlying challenges of designing a
-			product interface. Diète advocates for no-nonsense, unobtrusive design and clean elegance that
-			efficiently help everyone using your app.
-		</Typography>
+            Diète aims for simplicity and timeless design by avoiding superfluous effects or trendy styles. Not merely the superficial simplicity that comes from a minimalist appearance, but the simplicity that stems from deeply understanding the underlying challenges of designing a product interface. Diète advocates for no-nonsense, unobtrusive design and clean elegance that efficiently help everyone using your app.		</Typography>
 	</section>
 
 	<section id="fully-accessible">
-		<Typography variant="h5" class="box-title">Fully accessible (WIP)</Typography>
+		<Typography variant="h5" class="box-title">Fully accessible</Typography>
 		<Typography>
-			Diète complies to the highest usability standards and strives to be as inclusive as possible.
-			<ul>
-				<li>color contrast ratio</li>
-				<li>font sizes</li>
-				<li>component sizes</li>
-				<li>screen reader / no mouse</li>
-			</ul>
-		</Typography>
+            Diète complies to the highest usability standards and strives to be as inclusive as possible. Color contrast, fonts and default components sizes all feature Triple-A conformance to the latest Web Content Accessibility Guidelines (WCAG 2.2). Furthermore, all components come with carefully designed, high-emphasis focused states allowing people to easily interact without a mouse — using the keyboard or voice control.		</Typography>
 	</section>
 </ResponsiveContainer>
 
 <ResponsiveContainer class="vspace">
 	<section id="essential-design">
-		<Typography variant="h5" class="box-title">Flexible (WIP)</Typography>
+		<Typography variant="h5" class="box-title">Flexible</Typography>
 		<Typography>
-			Diète aims for simplicity Diète is designed with flexibility in mind.
-			<ul>
-				<li>Easy to combine components into vertical or horizontal layouts</li>
-				<li>Easy customisation color customisation</li>
-				<li>Easy fonts/icons change</li>
-				<li>Easy to change anything in the code, no dependencies</li>
-			</ul>
+            All components come in 4 sizes (default, compact, small and large) and variants for vertical or horizontal layouts. Margins and spacing are built in the components themselves, so they can be perfectly assembled together to build advanced layouts. Moreover, Diète comes with a dynamic colour system that generates light or dark themes from any colour. You can also change the default system fonts and icon set to your preferences.
 		</Typography>
 	</section>
 
 	<section id="no-dependencies">
-		<Typography variant="h5" class="box-title">No dependencies</Typography>
+		<Typography variant="h5" class="box-title">Minimum dependencies</Typography>
 		<Typography>
-			Diete is not a dependency you install, instead you download the source and copy the components
-			into your own project where they become the starting point for your own component system.
-		</Typography>
+            Diète is not a dependency you install. You download the source code and copy the components into your own project, where they become the starting point for your own component system. This way, you remain independent and gain complete control over the code. Diète comes with high-quality defaults that you can use as is, but you have the freedom to decide how to use and customise each component to your own needs. Your app, your code.		</Typography>
 	</section>
 </ResponsiveContainer>
 

--- a/src/routes/build/+page.svelte
+++ b/src/routes/build/+page.svelte
@@ -132,4 +132,18 @@
 	:global(.section-title) {
 		margin-bottom: var(--double-padding) !important;
 	}
+	ol {
+		counter-reset: li;
+		margin-left: 0;
+		padding-left: 0;
+		list-style: none;
+	}
+	ol li:before {
+		content: counter(li) '. ';
+		color: var(--colors-top);
+		font-family: var(--font-family-sans-serif);
+	}
+	ol li {
+		counter-increment: li;
+	}
 </style>

--- a/src/routes/build/+page.svelte
+++ b/src/routes/build/+page.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+	import ResponsiveContainer from '$lib/components/custom/responsive-container.svelte'
+    import Typography from '$lib/components/ui/typography.svelte'
+</script>
+
+<Typography variant="h3">Build with Diète</Typography>
+
+<section id="introduction">
+	<Typography>
+		Diète is an open-source design system. Guided by an essential design approach, built with the
+		highest usability standards, it lays great emphasis on accessibility and flexibility. UI
+		components can be copy-pasted directly into your own code, easily customised and assembled
+		together to build a wide variety of applications.
+	</Typography>
+</section>
+
+<hr/>
+
+<Typography variant="h4" class="section-title">Get started</Typography>
+
+<ol>
+    <li><Typography>Add the <a href="https://www.npmjs.com/package/carbon-icons-svelte">carbon-icons-svelte</a> package as a dependency that contains necessary icons.</Typography></li>
+    <li><Typography>Copy the <a href="/generated/css/diete.css">diete.css</a> file to your projects that contain shared variable definitions.</Typography></li>
+    <li><Typography>Find the component you need and copy the necessary files from the Implement section to your project.</Typography></li>
+</ol>
+
+<hr/>
+
+<Typography variant="h4" class="section-title">Why Diète</Typography>
+
+<section id="quote">
+    <Typography variant="large" font="serif" italic>“Good design is as little design as possible. Less, but better – because it concentrates on the essential aspects, and the products are not burdened with non-essentials. Back to purity, back to simplicity.”</Typography>
+    <Typography>— Dieter Rams</Typography>
+</section>
+
+<ResponsiveContainer class="vspace">
+    <section id="essential-design">
+        <Typography variant="h5" class="box-title">Essential design</Typography>
+        <Typography>
+            Diète aims for simplicity and timeless design by avoiding superfluous effects or trendy styles. Not merely the superficial simplicity that comes from a minimalist appearance, but the simplicity that stems from deeply understanding the underlying challenges of designing a product interface. Diète advocates for no-nonsense, unobtrusive design and clean elegance that efficiently help everyone using your app.
+        </Typography>
+    </section>
+
+    <section id="fully-accessible">
+        <Typography variant="h5" class="box-title">Fully accessible (WIP)</Typography>
+        <Typography>
+            Diète complies to the highest usability standards and strives to be as inclusive as possible. 
+            <ul>
+                <li>
+                    color contrast ratio 
+                </li>
+                <li>
+                    font sizes
+                </li>
+                <li>
+                    component sizes
+                </li>
+                <li>
+                    screen reader / no mouse
+                </li>
+            </ul>
+        </Typography>
+    </section>
+</ResponsiveContainer>
+
+<ResponsiveContainer class="vspace">
+    <section id="essential-design">
+        <Typography variant="h5" class="box-title">Flexible (WIP)</Typography>
+        <Typography>
+            Diète aims for simplicity Diète is designed with flexibility in mind.
+            <ul>
+                <li>
+                    Easy to combine components into vertical or horizontal layouts
+                </li>
+                <li>
+                    Easy customisation color customisation
+                </li>
+                <li>
+                    Easy fonts/icons change
+                </li>
+                <li>
+                    Easy to change anything in the code, no dependencies
+                </li>
+            </ul>
+        </Typography>
+    </section>
+            
+    <section id="no-dependencies">
+        <Typography variant="h5" class="box-title">No dependencies</Typography>
+        <Typography>
+            Diete is not a dependency you install, instead you download the source and copy the components into your own project where they become the starting point for your own component system.                    </Typography>
+    </section>
+</ResponsiveContainer>
+
+<hr/>
+
+
+<style lang="postcss">
+	#introduction {
+		margin-top: var(--double-padding);
+	}
+    #quote {
+        display: flex;
+        flex-direction: column;
+        gap: calc(var(--padding) / 2); /* TODO use half-padding */
+        margin-bottom: var(--double-padding);
+    }
+    hr {
+		appearance: none;
+		margin-top: var(--double-padding);
+		margin-bottom: var(--double-padding);
+		border-width: 1px;
+		border-style: solid;
+		width: 100%;
+		color: var(--colors-low);
+	}
+    :global(.vspace) {
+		margin-top: var(--padding);
+	}
+    :global(.box-title) {
+        margin-bottom: var(--half-padding) !important;
+    }
+    :global(.section-title) {
+        margin-bottom: var(--double-padding) !important;
+    }
+</style>

--- a/src/routes/build/+page.svelte
+++ b/src/routes/build/+page.svelte
@@ -21,14 +21,14 @@
 <ol>
 	<li>
 		<Typography
-			>Add the <a href="https://www.npmjs.com/package/carbon-icons-svelte">carbon-icons-svelte</a> package
-			as a dependency that contains necessary icons.</Typography
+			>Copy the <a href="/generated/css/diete.css">diete.css</a> file to your projects that contain shared
+			variable definitions. You may customize this file (<a href="/colors">colors</a>, fonts etc.) however you wish.</Typography
 		>
 	</li>
 	<li>
 		<Typography
-			>Copy the <a href="/generated/css/diete.css">diete.css</a> file to your projects that contain shared
-			variable definitions.</Typography
+			>Add the <a href="https://www.npmjs.com/package/carbon-icons-svelte">carbon-icons-svelte</a> package
+			as a dependency that contains necessary icons.</Typography
 		>
 	</li>
 	<li>

--- a/src/routes/build/+page.svelte
+++ b/src/routes/build/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import ResponsiveContainer from '$lib/components/custom/responsive-container.svelte'
-    import Typography from '$lib/components/ui/typography.svelte'
+	import Typography from '$lib/components/ui/typography.svelte'
 </script>
 
 <Typography variant="h3">Build with Diète</Typography>
@@ -14,98 +14,106 @@
 	</Typography>
 </section>
 
-<hr/>
+<hr />
 
 <Typography variant="h4" class="section-title">Get started</Typography>
 
 <ol>
-    <li><Typography>Add the <a href="https://www.npmjs.com/package/carbon-icons-svelte">carbon-icons-svelte</a> package as a dependency that contains necessary icons.</Typography></li>
-    <li><Typography>Copy the <a href="/generated/css/diete.css">diete.css</a> file to your projects that contain shared variable definitions.</Typography></li>
-    <li><Typography>Find the component you need and copy the necessary files from the Implement section to your project.</Typography></li>
+	<li>
+		<Typography
+			>Add the <a href="https://www.npmjs.com/package/carbon-icons-svelte">carbon-icons-svelte</a> package
+			as a dependency that contains necessary icons.</Typography
+		>
+	</li>
+	<li>
+		<Typography
+			>Copy the <a href="/generated/css/diete.css">diete.css</a> file to your projects that contain shared
+			variable definitions.</Typography
+		>
+	</li>
+	<li>
+		<Typography
+			>Find the component you need and copy the necessary files from the Implement section to your
+			project.</Typography
+		>
+	</li>
 </ol>
 
-<hr/>
+<hr />
 
 <Typography variant="h4" class="section-title">Why Diète</Typography>
 
 <section id="quote">
-    <Typography variant="large" font="serif" italic>“Good design is as little design as possible. Less, but better – because it concentrates on the essential aspects, and the products are not burdened with non-essentials. Back to purity, back to simplicity.”</Typography>
-    <Typography>— Dieter Rams</Typography>
+	<Typography variant="large" font="serif" italic
+		>“Good design is as little design as possible. Less, but better – because it concentrates on the
+		essential aspects, and the products are not burdened with non-essentials. Back to purity, back
+		to simplicity.”</Typography
+	>
+	<Typography>— Dieter Rams</Typography>
 </section>
 
 <ResponsiveContainer class="vspace">
-    <section id="essential-design">
-        <Typography variant="h5" class="box-title">Essential design</Typography>
-        <Typography>
-            Diète aims for simplicity and timeless design by avoiding superfluous effects or trendy styles. Not merely the superficial simplicity that comes from a minimalist appearance, but the simplicity that stems from deeply understanding the underlying challenges of designing a product interface. Diète advocates for no-nonsense, unobtrusive design and clean elegance that efficiently help everyone using your app.
-        </Typography>
-    </section>
+	<section id="essential-design">
+		<Typography variant="h5" class="box-title">Essential design</Typography>
+		<Typography>
+			Diète aims for simplicity and timeless design by avoiding superfluous effects or trendy
+			styles. Not merely the superficial simplicity that comes from a minimalist appearance, but the
+			simplicity that stems from deeply understanding the underlying challenges of designing a
+			product interface. Diète advocates for no-nonsense, unobtrusive design and clean elegance that
+			efficiently help everyone using your app.
+		</Typography>
+	</section>
 
-    <section id="fully-accessible">
-        <Typography variant="h5" class="box-title">Fully accessible (WIP)</Typography>
-        <Typography>
-            Diète complies to the highest usability standards and strives to be as inclusive as possible. 
-            <ul>
-                <li>
-                    color contrast ratio 
-                </li>
-                <li>
-                    font sizes
-                </li>
-                <li>
-                    component sizes
-                </li>
-                <li>
-                    screen reader / no mouse
-                </li>
-            </ul>
-        </Typography>
-    </section>
+	<section id="fully-accessible">
+		<Typography variant="h5" class="box-title">Fully accessible (WIP)</Typography>
+		<Typography>
+			Diète complies to the highest usability standards and strives to be as inclusive as possible.
+			<ul>
+				<li>color contrast ratio</li>
+				<li>font sizes</li>
+				<li>component sizes</li>
+				<li>screen reader / no mouse</li>
+			</ul>
+		</Typography>
+	</section>
 </ResponsiveContainer>
 
 <ResponsiveContainer class="vspace">
-    <section id="essential-design">
-        <Typography variant="h5" class="box-title">Flexible (WIP)</Typography>
-        <Typography>
-            Diète aims for simplicity Diète is designed with flexibility in mind.
-            <ul>
-                <li>
-                    Easy to combine components into vertical or horizontal layouts
-                </li>
-                <li>
-                    Easy customisation color customisation
-                </li>
-                <li>
-                    Easy fonts/icons change
-                </li>
-                <li>
-                    Easy to change anything in the code, no dependencies
-                </li>
-            </ul>
-        </Typography>
-    </section>
-            
-    <section id="no-dependencies">
-        <Typography variant="h5" class="box-title">No dependencies</Typography>
-        <Typography>
-            Diete is not a dependency you install, instead you download the source and copy the components into your own project where they become the starting point for your own component system.                    </Typography>
-    </section>
+	<section id="essential-design">
+		<Typography variant="h5" class="box-title">Flexible (WIP)</Typography>
+		<Typography>
+			Diète aims for simplicity Diète is designed with flexibility in mind.
+			<ul>
+				<li>Easy to combine components into vertical or horizontal layouts</li>
+				<li>Easy customisation color customisation</li>
+				<li>Easy fonts/icons change</li>
+				<li>Easy to change anything in the code, no dependencies</li>
+			</ul>
+		</Typography>
+	</section>
+
+	<section id="no-dependencies">
+		<Typography variant="h5" class="box-title">No dependencies</Typography>
+		<Typography>
+			Diete is not a dependency you install, instead you download the source and copy the components
+			into your own project where they become the starting point for your own component system.
+		</Typography>
+	</section>
 </ResponsiveContainer>
 
-<hr/>
-
+<hr />
 
 <style lang="postcss">
 	#introduction {
 		margin-top: var(--double-padding);
 	}
-    #quote {
-        display: flex;
-        flex-direction: column;
-        gap: calc(var(--padding) / 2); /* TODO use half-padding */
-        margin-bottom: var(--double-padding);
-    }
-    hr {
+	#quote {
+		display: flex;
+		flex-direction: column;
+		gap: calc(var(--padding) / 2); /* TODO use half-padding */
+		margin-bottom: var(--double-padding);
+	}
+	hr {
 		appearance: none;
 		margin-top: var(--double-padding);
 		margin-bottom: var(--double-padding);
@@ -114,13 +122,13 @@
 		width: 100%;
 		color: var(--colors-low);
 	}
-    :global(.vspace) {
+	:global(.vspace) {
 		margin-top: var(--padding);
 	}
-    :global(.box-title) {
-        margin-bottom: var(--half-padding) !important;
-    }
-    :global(.section-title) {
-        margin-bottom: var(--double-padding) !important;
-    }
+	:global(.box-title) {
+		margin-bottom: var(--half-padding) !important;
+	}
+	:global(.section-title) {
+		margin-bottom: var(--double-padding) !important;
+	}
 </style>

--- a/src/routes/build/+page.svelte
+++ b/src/routes/build/+page.svelte
@@ -21,20 +21,22 @@
 <ol>
 	<li>
 		<Typography
-			>Copy the <a href="/generated/css/diete.css">diete.css</a> file to your projects that contain shared
-			variable definitions. You may customize this file (<a href="/colors">colors</a>, fonts etc.) however you wish.</Typography
-		>
-	</li>
-	<li>
-		<Typography
-			>Add the <a href="https://www.npmjs.com/package/carbon-icons-svelte">carbon-icons-svelte</a> package
-			as a dependency that contains necessary icons.</Typography
+			>Copy the <a href="/generated/css/diete.css">diete.css</a> file to your projects that contain
+			shared variable definitions. You may customize this file (<a href="/colors">colors</a>, fonts
+			etc.) however you wish.</Typography
 		>
 	</li>
 	<li>
 		<Typography
 			>Find the component you need and copy the necessary files from the Implement section to your
 			project.</Typography
+		>
+	</li>
+	<li>
+		<Typography
+			>Optional step: add the <a href="https://www.npmjs.com/package/carbon-icons-svelte"
+				>carbon-icons-svelte</a
+			> package as a dependency that contains necessary icons.</Typography
 		>
 	</li>
 </ol>
@@ -56,13 +58,23 @@
 	<section id="essential-design">
 		<Typography variant="h5" class="box-title">Essential design</Typography>
 		<Typography>
-            Diète aims for simplicity and timeless design by avoiding superfluous effects or trendy styles. Not merely the superficial simplicity that comes from a minimalist appearance, but the simplicity that stems from deeply understanding the underlying challenges of designing a product interface. Diète advocates for no-nonsense, unobtrusive design and clean elegance that efficiently help everyone using your app.		</Typography>
+			Diète aims for simplicity and timeless design by avoiding superfluous effects or trendy
+			styles. Not merely the superficial simplicity that comes from a minimalist appearance, but the
+			simplicity that stems from deeply understanding the underlying challenges of designing a
+			product interface. Diète advocates for no-nonsense, unobtrusive design and clean elegance that
+			efficiently help everyone using your app.
+		</Typography>
 	</section>
 
 	<section id="fully-accessible">
 		<Typography variant="h5" class="box-title">Fully accessible</Typography>
 		<Typography>
-            Diète complies to the highest usability standards and strives to be as inclusive as possible. Color contrast, fonts and default components sizes all feature Triple-A conformance to the latest Web Content Accessibility Guidelines (WCAG 2.2). Furthermore, all components come with carefully designed, high-emphasis focused states allowing people to easily interact without a mouse — using the keyboard or voice control.		</Typography>
+			Diète complies to the highest usability standards and strives to be as inclusive as possible.
+			Color contrast, fonts and default components sizes all feature Triple-A conformance to the
+			latest Web Content Accessibility Guidelines (WCAG 2.2). Furthermore, all components come with
+			carefully designed, high-emphasis focused states allowing people to easily interact without a
+			mouse — using the keyboard or voice control.
+		</Typography>
 	</section>
 </ResponsiveContainer>
 
@@ -70,14 +82,23 @@
 	<section id="essential-design">
 		<Typography variant="h5" class="box-title">Flexible</Typography>
 		<Typography>
-            All components come in 4 sizes (default, compact, small and large) and variants for vertical or horizontal layouts. Margins and spacing are built in the components themselves, so they can be perfectly assembled together to build advanced layouts. Moreover, Diète comes with a dynamic colour system that generates light or dark themes from any colour. You can also change the default system fonts and icon set to your preferences.
+			All components come in 4 sizes (default, compact, small and large) and variants for vertical
+			or horizontal layouts. Margins and spacing are built in the components themselves, so they can
+			be perfectly assembled together to build advanced layouts. Moreover, Diète comes with a
+			dynamic colour system that generates light or dark themes from any colour. You can also change
+			the default system fonts and icon set to your preferences.
 		</Typography>
 	</section>
 
 	<section id="no-dependencies">
 		<Typography variant="h5" class="box-title">Minimum dependencies</Typography>
 		<Typography>
-            Diète is not a dependency you install. You download the source code and copy the components into your own project, where they become the starting point for your own component system. This way, you remain independent and gain complete control over the code. Diète comes with high-quality defaults that you can use as is, but you have the freedom to decide how to use and customise each component to your own needs. Your app, your code.		</Typography>
+			Diète is not a dependency you install. You download the source code and copy the components
+			into your own project, where they become the starting point for your own component system.
+			This way, you remain independent and gain complete control over the code. Diète comes with
+			high-quality defaults that you can use as is, but you have the freedom to decide how to use
+			and customise each component to your own needs. Your app, your code.
+		</Typography>
 	</section>
 </ResponsiveContainer>
 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -8,12 +8,12 @@ const DIST_DIR = './static/generated/css'
 async function copyDieteCss() {
 	const dieteCssFilename = 'diete.css'
 	const dieteCss = fs.readFileSync(`./src/${dieteCssFilename}`, { encoding: 'utf-8' })
-	console.debug({ dieteCss })
 	const prettierOptions = await prettier.resolveConfig('.prettierrc')
 	const prettifiedCode = await prettier.format(dieteCss, {
 		...prettierOptions,
 		parser: 'css',
 	})
+	fs.mkdirSync(DIST_DIR, { recursive: true })
 	fs.writeFileSync(`${DIST_DIR}/${dieteCssFilename}`, prettifiedCode)
 }
 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -12,6 +12,7 @@ function cssPreprocess() {
 	return {
 		...vite,
 		async style(args) {
+			console.debug(args.filename)
 			const prettierOptions = await prettier.resolveConfig('.prettierrc')
 			const preprocessedStyle = await viteStyle(args)
 			const match = args.filename.match(/^.*\/src\/lib\/components(.*\/)(.*)\.svelte/)
@@ -29,6 +30,7 @@ function cssPreprocess() {
 				})
 				fs.writeFileSync(cssFilePath, prettifiedCode)
 			}
+
 			return preprocessedStyle
 		},
 	}


### PR DESCRIPTION
This PR separates the `app.pcss` file and a `diete.css` file. The former contains styles for the website, the latter contains the variable definitions that the components use.

Other small changes:
- Add link to `/colors` page
- Add border to menu
- Made menu always open