### PR TITLE
fix: components in menu

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -25,7 +25,7 @@
 			'/colors': 'CSS colors',
 			'https://github.com/diete-design/diete.design': 'Github',
 		},
-		'Basic components': {
+		'Components': {
 			'/components/badge': 'Badge',
 			'/components/button': 'Button',
 			'/components/checkbox': 'Checkbox',

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -25,7 +25,7 @@
 			'/colors': 'CSS colors',
 			'https://github.com/diete-design/diete.design': 'Github',
 		},
-		'Components': {
+		Components: {
 			'/components/badge': 'Badge',
 			'/components/button': 'Button',
 			'/components/checkbox': 'Checkbox',


### PR DESCRIPTION
Change `Basic components` to simply `Components`  for now.