### PR TITLE
fix: input default font family

### DIFF
--- a/src/lib/components/ui/input.svelte
+++ b/src/lib/components/ui/input.svelte
@@ -134,6 +134,9 @@
 </div>
 
 <style lang="postcss">
+	input {
+		font-family: var(--font-family-sans-serif);
+	}
 	input[type='number']::-webkit-outer-spin-button,
 	input[type='number']::-webkit-inner-spin-button {
 		appearance: none;


### PR DESCRIPTION
Without this fix the input component always render with the browser default font and not the one defined in `diete.css`.